### PR TITLE
Replaced deprecated getchildren() call.

### DIFF
--- a/evoman/tmx.py
+++ b/evoman/tmx.py
@@ -78,7 +78,7 @@ class Tileset(object):
 
         tileset = cls(name, tile_width, tile_height, firstgid)
 
-        for c in tag.getchildren():
+        for c in tag:
             if c.tag == "image":
                 # create a tileset
                 tileset.add_image(c.attrib['source'])


### PR DESCRIPTION
The `getchildren()` function is deprecated since version 3.2 and removed in version 3.9. See also: https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren

This change will make the framework work with python 3.9 again and should not affect users with older python versions.

This solution was originally found by Duncan Bart: https://canvas.vu.nl/courses/55486/discussion_topics/420902